### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,6 @@
 name: Deploy to Server
+permissions:
+  contents: write
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/nokibsarkar/campwiz-backend/security/code-scanning/1](https://github.com/nokibsarkar/campwiz-backend/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions performed in the workflow, the `contents: read` permission is sufficient for most steps, but `contents: write` is required for deployment steps that involve sending builds to the server. We will also ensure no unnecessary permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
