### PR TITLE
Fix GORM zero-value skipping for all boolean fields in round updates

### DIFF
--- a/repository/round.go
+++ b/repository/round.go
@@ -20,18 +20,27 @@ func (r *RoundRepository) Create(conn *gorm.DB, round *models.Round) (*models.Ro
 	return round, nil
 }
 func (r *RoundRepository) Update(conn *gorm.DB, round *models.Round) (*models.Round, error) {
-	IsPublic := round.IsPublicJury
-	result := conn.Updates(round)
-	if result.Error != nil {
-		return nil, result.Error
+	booleanColumns := []string{
+		"is_public_jury", "is_open", "allow_jury_to_participate",
+		"allow_multiple_judgement", "secret_ballot",
+		"article_allow_expansions", "article_allow_creations",
 	}
-	q := query.Use(conn)
-	res, err := q.Round.Where(q.Round.RoundID.Eq(round.RoundID.String())).Update(q.Round.IsPublicJury, IsPublic)
-	if err != nil {
+	if err := conn.Omit(booleanColumns...).Updates(round).Error; err != nil {
 		return nil, err
 	}
-	if res.Error != nil {
-		return nil, res.Error
+	// GORM's Updates skips zero-value fields; for booleans false is the zero
+	// value, so we must force-update every boolean column explicitly.
+	booleans := map[string]interface{}{
+		"is_public_jury":            round.IsPublicJury,
+		"is_open":                   round.IsOpen,
+		"allow_jury_to_participate": round.AllowJuryToParticipate,
+		"allow_multiple_judgement":  round.AllowMultipleJudgement,
+		"secret_ballot":             round.SecretBallot,
+		"article_allow_expansions":  round.ArticleAllowExpansions,
+		"article_allow_creations":   round.ArticleAllowCreations,
+	}
+	if err := conn.Model(round).Updates(booleans).Error; err != nil {
+		return nil, err
 	}
 	return round, nil
 }


### PR DESCRIPTION
In Go, false is the zero value for bool. So when the frontend sends `allowJuryToParticipate: false`, for example, the backend correctly parses it, but when GORM runs the SQL UPDATE, it sees false (zero value) and omits it from the query entirely, leaving the existing true in the database unchanged.

GORM's `Updates()` silently skips zero-value fields, so boolean fields set to false are never persisted. A previous workaround in the codebase handled IsPublicJury individually via the query builder, but left `AllowJuryToParticipate`, `AllowMultipleJudgement`, `SecretBallot`, `IsOpen`, `ArticleAllowExpansions`, and `ArticleAllowCreations` unfixed. This PR replaces the single-field workaround with an explicit map-based update covering all boolean columns.